### PR TITLE
fixed(cafeteria): lib global export sample

### DIFF
--- a/packages/cafeteria/app/lib/scripts/cdp.deviceconsole/_declare.d.ts
+++ b/packages/cafeteria/app/lib/scripts/cdp.deviceconsole/_declare.d.ts
@@ -1,14 +1,4 @@
-﻿/// <reference path="./_export.d.ts" />
-
-/*
- * [NOTE] global declaration
- *
- * 以下のように global オブジェクトにアサイン可能
- * ※既存の cdp.ui.*.js に実装する場合は、従来どおり classical module 方式にすること
- */
-declare namespace CDP {
-    const DeviceConsole: typeof LibDeviceConsole.DeviceConsole;
-}
+/// <reference path="./_export.d.ts" />
 
 declare module "cdp.deviceconsole" {
     export = LibDeviceConsole;

--- a/packages/cafeteria/app/lib/scripts/cdp.deviceconsole/main.ts
+++ b/packages/cafeteria/app/lib/scripts/cdp.deviceconsole/main.ts
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * [NOTE] AMD entries module must be named for releases build
  *
  * 生成する d.ts に AMD module 名を設定するために、
@@ -13,7 +13,8 @@
  * release ビルド時において、複数の module 間で内部で使用される AMD module 名のコンフリクト避けるため、
  * 必ず namespace path がシステム内で一意となるように管理することが必須
  */
-import DeviceConsole from "./cdp/device-console";
+import _DeviceConsole from "./cdp/device-console";
+export { _DeviceConsole as DeviceConsole };
 
 /*
  * [NOTE] global export
@@ -25,7 +26,17 @@ import DeviceConsole from "./cdp/device-console";
 /* tslint:disable:no-string-literal */
 const global = Function("return this")();
 global["CDP"] = global["CDP"] || {};
-global["CDP"].DeviceConsole = DeviceConsole;
+global["CDP"].DeviceConsole = _DeviceConsole;
 /* tslint:enable:no-string-literal */
 
-export { DeviceConsole };
+/*
+ * [NOTE] global declaration
+ *
+ * 以下のように global オブジェクトにアサイン可能
+ * ※既存の cdp.ui.*.js に実装する場合は、従来どおり classical module 方式にすること
+ */
+declare global {
+    namespace CDP {
+        const DeviceConsole: typeof _DeviceConsole;
+    }
+}

--- a/packages/cafeteria/app/lib/scripts/cdp.slideshow/_declare.d.ts
+++ b/packages/cafeteria/app/lib/scripts/cdp.slideshow/_declare.d.ts
@@ -1,14 +1,4 @@
-﻿/// <reference path="./_export.d.ts" />
-
-/*
- * [NOTE] global declaration
- *
- * 以下のように global オブジェクトにアサイン可能
- * ※既存の cdp.ui.*.js に実装する場合は、従来どおり classical module 方式にすること
- */
-declare namespace CDP {
-    const SlideShow: typeof LibSlideShow.SlideShow;
-}
+/// <reference path="./_export.d.ts" />
 
 declare module "cdp.slideshow" {
     export = LibSlideShow;

--- a/packages/cafeteria/app/lib/scripts/cdp.slideshow/main.ts
+++ b/packages/cafeteria/app/lib/scripts/cdp.slideshow/main.ts
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * [NOTE] AMD entries module must be named for releases build
  *
  * 生成する d.ts に AMD module 名を設定するために、
@@ -13,7 +13,8 @@
  * release ビルド時において、複数の module 間で内部で使用される AMD module 名のコンフリクト避けるため、
  * 必ず namespace path がシステム内で一意となるように管理することが必須
  */
-import * as SlideShow from "./cdp/slideshow/player";
+import * as _SlideShow from "./cdp/slideshow/player";
+export { _SlideShow as SlideShow };
 
 /*
  * [NOTE] global export
@@ -25,8 +26,17 @@ import * as SlideShow from "./cdp/slideshow/player";
 /* tslint:disable:no-string-literal */
 const global = Function("return this")();
 global["CDP"] = global["CDP"] || {};
-global["CDP"].SlideShow = SlideShow;
+global["CDP"].SlideShow = _SlideShow;
 /* tslint:enable:no-string-literal */
 
-//export default SlideShowPlayer;
-export { SlideShow };
+/*
+ * [NOTE] global declaration
+ *
+ * 以下のように global オブジェクトにアサイン可能
+ * ※既存の cdp.ui.*.js に実装する場合は、従来どおり classical module 方式にすること
+ */
+declare global {
+    namespace CDP {
+        const SlideShow: typeof _SlideShow;
+    }
+}

--- a/packages/cafeteria/app/lib/scripts/cdp.ui.smoothscroll/_declare.d.ts
+++ b/packages/cafeteria/app/lib/scripts/cdp.ui.smoothscroll/_declare.d.ts
@@ -1,14 +1,4 @@
-﻿/// <reference path="./_export.d.ts" />
-
-/*
- * [NOTE] global declaration
- *
- * 以下のように global オブジェクトにアサイン可能
- * ※既存の cdp.ui.*.js に実装する場合は、従来どおり classical module 方式にすること
- */
-declare namespace CDP.UI {
-    const SmoothScroll: typeof LibSmoothScroll.SmoothScroll;
-}
+/// <reference path="./_export.d.ts" />
 
 declare module "cdp.ui.smoothscroll" {
     export = LibSmoothScroll;

--- a/packages/cafeteria/app/lib/scripts/cdp.ui.smoothscroll/main.ts
+++ b/packages/cafeteria/app/lib/scripts/cdp.ui.smoothscroll/main.ts
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * [NOTE] AMD entries module must be named for releases build
  *
  * 生成する d.ts に AMD module 名を設定するために、
@@ -13,7 +13,8 @@
  * release ビルド時において、複数の module 間で内部で使用される AMD module 名のコンフリクト避けるため、
  * 必ず namespace path がシステム内で一意となるように管理することが必須
  */
-import SmoothScroll from "./cdp/ui/smooth-scroll";
+import _SmoothScroll from "./cdp/ui/smooth-scroll";
+export { _SmoothScroll as SmoothScroll };
 
 /*
  * [NOTE] global export
@@ -26,7 +27,17 @@ import SmoothScroll from "./cdp/ui/smooth-scroll";
 const global = Function("return this")();
 global["CDP"]       = global["CDP"] || {};
 global["CDP"]["UI"] = global["CDP"]["UI"] || {};
-global["CDP"]["UI"].SmoothScroll = SmoothScroll;
+global["CDP"]["UI"].SmoothScroll = _SmoothScroll;
 /* tslint:enable:no-string-literal */
 
-export { SmoothScroll };
+/*
+ * [NOTE] global declaration
+ *
+ * 以下のように global オブジェクトにアサイン可能
+ * ※既存の cdp.ui.*.js に実装する場合は、従来どおり classical module 方式にすること
+ */
+declare global {
+    namespace CDP {
+        const SmoothScroll: typeof _SmoothScroll;
+    }
+}

--- a/packages/cafeteria/app/scripts/model/options.ts
+++ b/packages/cafeteria/app/scripts/model/options.ts
@@ -1,6 +1,8 @@
-﻿import { Model, ModelSetOptions } from "cdp/framework";
+import { Model, ModelSetOptions } from "cdp/framework";
 import { Toast, Theme } from "cdp/ui";
 import { DeviceConsole } from "cdp.deviceconsole";
+// DeviceConsole は CDP.DeviceConsole からのアクセスも許可しているため、以下の記述も可能
+// import DeviceConsole = CDP.DeviceConsole;
 
 const TAG = "[model.Options] ";
 


### PR DESCRIPTION
- lib 開発時に global export する場合の declaration の誤りを修正
  - cdp.deviceconsole
  - cdp.slideshow
  - cdp.ui.smoothscroll