### PR TITLE
updated: cdp-tools/Binary.ts

### DIFF
--- a/packages/cafeteria/app/lib/scripts/cdp.storage/cdp/storage/utils.ts
+++ b/packages/cafeteria/app/lib/scripts/cdp.storage/cdp/storage/utils.ts
@@ -12,12 +12,14 @@ import { RESULT_CODE } from "./error-defs";
 
 const arrayBufferToBase64   = Tools.Binary.arrayBufferToBase64;
 const uint8ArrayToBase64    = Tools.Binary.uint8ArrayToBase64;
-const base64ToBlob          = Tools.Binary.base64ToBlob;
 const base64ToArrayBuffer   = Tools.Binary.base64ToArrayBuffer;
 const base64ToUint8Array    = Tools.Binary.base64ToUint8Array;
 const arrayBufferToBlob     = Tools.Binary.arrayBufferToBlob;
-const readBlobAsUint8Array  = Tools.Binary.readBlobAsUint8Array;
+const uint8ArrayToBlob      = Tools.Binary.uint8ArrayToBlob;
+const base64ToBlob          = Tools.Binary.base64ToBlob;
 const readBlobAsArrayBuffer = Tools.Binary.readBlobAsArrayBuffer;
+const readBlobAsUint8Array  = Tools.Binary.readBlobAsUint8Array;
+const readBlobAsBase64      = Tools.Binary.readBlobAsBase64;
 const readBlobAsText        = Tools.Binary.readBlobAsText;
 
 const TAG = "[cdp.storage.utils] ";
@@ -28,9 +30,8 @@ function binaryToBase64(data: Blob | ArrayBuffer | Uint8Array): IPromise<string>
         let base64: string;
 
         if (data instanceof Blob) {
-            dependOn(readBlobAsArrayBuffer(data))
-                .then((buffer: ArrayBuffer) => {
-                    base64 = arrayBufferToBase64(buffer);
+            dependOn(readBlobAsBase64(data))
+                .then((base64: string) => {
                     resolve(base64);
                 })
                 .catch((error) => {
@@ -171,7 +172,7 @@ export function convertAsDataBlob(data: any, mimeType: string): IPromise<Blob> {
             } else if (data instanceof ArrayBuffer) {
                 blob = arrayBufferToBlob(data, mimeType || MIME_TYPE_BINRAY_DATA);
             } else if (data instanceof Uint8Array) {
-                blob = arrayBufferToBlob((<Uint8Array>data).buffer, mimeType || MIME_TYPE_BINRAY_DATA);
+                blob = uint8ArrayToBlob(data, mimeType || MIME_TYPE_BINRAY_DATA);
             } else {
                 try {
                     const text = JSON.stringify(data);

--- a/packages/cafeteria/app/scripts/view/nativebridge-sample/root.ts
+++ b/packages/cafeteria/app/scripts/view/nativebridge-sample/root.ts
@@ -285,7 +285,7 @@ class RootPageView extends PageView {
             root: this.getDeviceStorageRoot(root),
             dataInfo: {
                 dataType: ("json" === dataType) ? "text" : "blob",
-                mimeType: "image/png",
+                mimeType: "image/jpeg",
             },
             namespace: SECURE_STORAGE_NAMESPACE,
         }))

--- a/packages/cdp-tools/src/scripts/CDP/Tools/Binary.ts
+++ b/packages/cdp-tools/src/scripts/CDP/Tools/Binary.ts
@@ -127,8 +127,9 @@
          * @return {Blob} Blob data
          */
         public static base64ToBlob(base64: string, mimeType: string = "text/plain"): Blob {
-            const binstr = window.atob(base64);
-            return Binary.newBlob([binstr], { type: mimeType });
+            const bytes = Binary.base64ToByteString(base64);
+            const array = Binary.byteStringToUint8Array(bytes);
+            return Binary.uint8ArrayToBlob(array, mimeType);
         }
 
         /**
@@ -291,7 +292,8 @@
          * Base64 string to Uint8Array
          */
         public static base64ToUint8Array(base64: string): Uint8Array {
-            return Binary.byteStringToUint8Array(Binary.base64ToByteString(base64));
+            const bytes = Binary.base64ToByteString(base64);
+            return Binary.byteStringToUint8Array(bytes);
         }
 
         /**
@@ -306,7 +308,8 @@
          * text string to Uint8Array
          */
         public static textToUint8Array(text: string): Uint8Array {
-            return Binary.byteStringToUint8Array(Binary.textToByteString(text));
+            const bytes = Binary.textToByteString(text);
+            return Binary.byteStringToUint8Array(bytes);
         }
 
         /**
@@ -342,14 +345,16 @@
          * Uint8Array to Base64 string
          */
         public static uint8ArrayToBase64(array: Uint8Array): string {
-            return Binary.byteStringToBase64(Binary.uint8ArrayToByteString(array));
+            const bytes = Binary.uint8ArrayToByteString(array);
+            return Binary.byteStringToBase64(bytes);
         }
 
         /**
          * Uint8Array to text string
          */
         public static uint8ArrayToText(array: Uint8Array): string {
-            return Binary.byteStringToText(Binary.uint8ArrayToByteString(array));
+            const bytes = Binary.uint8ArrayToByteString(array);
+            return Binary.byteStringToText(bytes);
         }
 
         /**
@@ -369,7 +374,8 @@
          * Base64 string to text string
          */
         public static base64ToText(base64: string): string {
-            return Binary.byteStringToText(Binary.base64ToByteString(base64));
+            const bytes = Binary.base64ToByteString(base64);
+            return Binary.byteStringToText(bytes);
         }
 
         /**
@@ -384,7 +390,8 @@
          * text string to Base64 string
          */
         public static textToBase64(text: string): string {
-            return Binary.byteStringToBase64(Binary.textToByteString(text));
+            const bytes = Binary.textToByteString(text);
+            return Binary.byteStringToBase64(bytes);
         }
 
         /**

--- a/packages/cdp-tools/tests/unit/Binary.spec.ts
+++ b/packages/cdp-tools/tests/unit/Binary.spec.ts
@@ -41,18 +41,19 @@ describe("Tools.Binary", () => {
 
     it("Blob <=> ArrayBuffer", (done) => {
         // from ArrayBuffer to Blob
-        const size = 8;
+        const array = new Uint8Array([0, 1, 2, 3]);
+        const buffer = array.buffer;
         const type = "application/octet-stream";
-        const buffer = new ArrayBuffer(size);
         const blob = Binary.arrayBufferToBlob(buffer, type);
         expect(blob).toBeDefined();
-        expect(blob.size).toBe(size);
+        expect(blob.size).toBe(buffer.byteLength);
         expect(blob.type).toBe(type);
 
         // from Blob to ArrayBuffer
         Binary.readBlobAsArrayBuffer(blob)
             .then((retval) => {
-                expect(retval).toEqual(buffer);
+                const result = new Uint8Array(retval);
+                expect(result).toEqual(array);
                 done();
             })
             .catch((reason) => {
@@ -63,17 +64,17 @@ describe("Tools.Binary", () => {
 
     it("Blob <=> Uint8Array", (done) => {
         // from Uint8Array to Blob
-        const arr = new Uint8Array([0, 1, 2, 3]);
+        const array = new Uint8Array([0, 1, 2, 3]);
         const type = "application/octet-stream";
-        const blob = Binary.uint8ArrayToBlob(arr, type);
+        const blob = Binary.uint8ArrayToBlob(array, type);
         expect(blob).toBeDefined();
-        expect(blob.size).toBe(arr.byteLength);
+        expect(blob.size).toBe(array.byteLength);
         expect(blob.type).toBe(type);
 
         // from Blob to Uint8Array
         Binary.readBlobAsUint8Array(blob)
             .then((retval) => {
-                expect(retval).toEqual(arr);
+                expect(retval).toEqual(array);
                 done();
             })
             .catch((reason) => {
@@ -84,10 +85,12 @@ describe("Tools.Binary", () => {
 
     it("Blob <=> dataURL", (done) => {
         // from dataURL to Blob
-        const dataURL = "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==";  // "Hello, World!
+        const text = "Hello, CDP!";
+        const type = "text/plain";
+        const dataURL = Binary.textToDataURL(text, type);
         const blob = Binary.dataURLToBlob(dataURL);
         expect(blob).toBeDefined();
-        expect(blob.type).toBe("text/plain");
+        expect(blob.type).toBe(type);
 
         // from Blob to DataUrl
         Binary.readBlobAsDataURL(blob)
@@ -103,12 +106,12 @@ describe("Tools.Binary", () => {
 
     it("Blob <=> Base64", (done) => {
         // from Base64 to Blob
-        const str = "Hello%2C%20World!";    // escaped "Hello, World!"
-        const base64 = window.btoa(str);
-        const mimeType = "text/plain";
-        const blob = Binary.base64ToBlob(base64, mimeType);
+        const text = "Hello, CDP!";
+        const base64 = Binary.textToBase64(text);
+        const type = "text/plain";
+        const blob = Binary.base64ToBlob(base64, type);
         expect(blob).toBeDefined();
-        expect(blob.type).toBe(mimeType);
+        expect(blob.type).toBe(type);
 
         // from Blob to Base64
         Binary.readBlobAsBase64(blob)
@@ -124,11 +127,11 @@ describe("Tools.Binary", () => {
 
     it("Blob <=> Text", (done) => {
         // from Text to Blob
-        const text = "Hello, World!";
-        const mimeType = "text/plain";
-        const blob = Binary.textToBlob(text, mimeType);
+        const text = "Hello, CDP!";
+        const type = "text/plain";
+        const blob = Binary.textToBlob(text, type);
         expect(blob).toBeDefined();
-        expect(blob.type).toBe(mimeType);
+        expect(blob.type).toBe(type);
 
         // from Blob to Text
         Binary.readBlobAsText(blob)

--- a/packages/cdp-tools/tests/unit/Binary.spec.ts
+++ b/packages/cdp-tools/tests/unit/Binary.spec.ts
@@ -82,8 +82,8 @@ describe("Tools.Binary", () => {
             });
     });
 
-    it("Blob <=> DataUrl", (done) => {
-        // from DataUrl to Blob
+    it("Blob <=> dataURL", (done) => {
+        // from dataURL to Blob
         const dataURL = "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==";  // "Hello, World!
         const blob = Binary.dataURLToBlob(dataURL);
         expect(blob).toBeDefined();
@@ -140,5 +140,21 @@ describe("Tools.Binary", () => {
                 console.error(reason);
                 expect(null).toBe("THIS FLOW IS BUG.");
             });
+    });
+
+    it("ArrayBuffer => dataURL => text", () => {
+        const text = "Hello, CDP!";
+        const buffer = Binary.textToArrayBuffer(text);
+        const dataURL = Binary.arrayBufferToDataURL(buffer);
+        const result = Binary.dataURLToText(dataURL);
+        expect(result).toBe(text);
+    });
+
+    it("ArrayBuffer <= dataURL <= text", () => {
+        const text = "Hello, CDP!";
+        const dataURL = Binary.textToDataURL(text);
+        const buffer = Binary.dataURLToArrayBuffer(dataURL);
+        const result = Binary.arrayBufferToText(buffer);
+        expect(result).toBe(text);
     });
 });

--- a/packages/cdp-tools/tests/unit/Binary.spec.ts
+++ b/packages/cdp-tools/tests/unit/Binary.spec.ts
@@ -1,0 +1,144 @@
+﻿import "../../src/scripts/cdp.tools";
+
+import Binary = CDP.Tools.Binary;
+
+describe("Tools.Binary", () => {
+    beforeEach(() => {
+        // noop.
+    });
+
+    afterEach(() => {
+        // noop.
+    });
+
+    it("newBlob()", () => {
+        const blob = Binary.newBlob();
+        expect(blob).toBeDefined();
+        expect(blob.size).toBe(0);
+        expect(blob.type).toBe("");
+    });
+
+    it("newBlob(blobParts)", () => {
+        const parts = ['<a id="a"><b id="b">hey!</b></a>']; // tslint:disable-line:quotemark
+        const blob = new Blob(parts);
+        expect(blob).toBeDefined();
+        expect(blob.size).toBeGreaterThan(0);
+        expect(blob.type).toBe("");
+    });
+
+    it("newBlob(blobParts, options)", () => {
+        const parts = ['<a id="a"><b id="b">hey!</b></a>']; // tslint:disable-line:quotemark
+        const type = "text/html";
+        const blob = new Blob(parts, { type });
+        expect(blob).toBeDefined();
+        expect(blob.size).toBeGreaterThan(0);
+        expect(blob.type).toBe(type);
+    });
+
+    it("blobURL", () => {
+        expect(Binary.blobURL).toBeDefined();
+    });
+
+    it("Blob <=> ArrayBuffer", (done) => {
+        // from ArrayBuffer to Blob
+        const size = 8;
+        const type = "application/octet-stream";
+        const buffer = new ArrayBuffer(size);
+        const blob = Binary.arrayBufferToBlob(buffer, type);
+        expect(blob).toBeDefined();
+        expect(blob.size).toBe(size);
+        expect(blob.type).toBe(type);
+
+        // from Blob to ArrayBuffer
+        Binary.readBlobAsArrayBuffer(blob)
+            .then((retval) => {
+                expect(retval).toEqual(buffer);
+                done();
+            })
+            .catch((reason) => {
+                console.error(reason);
+                expect(null).toBe("THIS FLOW IS BUG.");
+            });
+    });
+
+    it("Blob <=> Uint8Array", (done) => {
+        // from Uint8Array to Blob
+        const arr = new Uint8Array([0, 1, 2, 3]);
+        const type = "application/octet-stream";
+        const blob = Binary.uint8ArrayToBlob(arr, type);
+        expect(blob).toBeDefined();
+        expect(blob.size).toBe(arr.byteLength);
+        expect(blob.type).toBe(type);
+
+        // from Blob to Uint8Array
+        Binary.readBlobAsUint8Array(blob)
+            .then((retval) => {
+                expect(retval).toEqual(arr);
+                done();
+            })
+            .catch((reason) => {
+                console.error(reason);
+                expect(null).toBe("THIS FLOW IS BUG.");
+            });
+    });
+
+    it("Blob <=> DataUrl", (done) => {
+        // from DataUrl to Blob
+        const dataURL = "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==";  // "Hello, World!
+        const blob = Binary.dataURLToBlob(dataURL);
+        expect(blob).toBeDefined();
+        expect(blob.type).toBe("text/plain");
+
+        // from Blob to DataUrl
+        Binary.readBlobAsDataURL(blob)
+            .then((retval) => {
+                expect(retval).toEqual(dataURL);
+                done();
+            })
+            .catch((reason) => {
+                console.error(reason);
+                expect(null).toBe("THIS FLOW IS BUG.");
+            });
+    });
+
+    it("Blob <=> Base64", (done) => {
+        // from Base64 to Blob
+        const str = "Hello%2C%20World!";    // escaped "Hello, World!"
+        const base64 = window.btoa(str);
+        const mimeType = "text/plain";
+        const blob = Binary.base64ToBlob(base64, mimeType);
+        expect(blob).toBeDefined();
+        expect(blob.type).toBe(mimeType);
+
+        // from Blob to Base64
+        Binary.readBlobAsBase64(blob)
+            .then((retval) => {
+                expect(retval).toEqual(base64);
+                done();
+            })
+            .catch((reason) => {
+                console.error(reason);
+                expect(null).toBe("THIS FLOW IS BUG.");
+            });
+    });
+
+    it("Blob <=> Text", (done) => {
+        // from Text to Blob
+        const text = "Hello, World!";
+        const mimeType = "text/plain";
+        const blob = Binary.textToBlob(text, mimeType);
+        expect(blob).toBeDefined();
+        expect(blob.type).toBe(mimeType);
+
+        // from Blob to Text
+        Binary.readBlobAsText(blob)
+            .then((retval) => {
+                expect(retval).toEqual(text);
+                done();
+            })
+            .catch((reason) => {
+                console.error(reason);
+                expect(null).toBe("THIS FLOW IS BUG.");
+            });
+    });
+});


### PR DESCRIPTION
## UPDATED PR INFO

### Binary.ts supports convert functions with all types of these data.
* Blob
* ArrayBuffer
* Uint8Array
* data URL (string)
* Base64 (string)
* text (string)


## OLD INFO BELOW

### In Binary.ts, blob convert functions are implemented.
* Blob <=> ArrayBuffer
* Blob <=> Uinta8Array
* Blob <=> DataURL
* Blob <=> Base64
* Blob <=> Text

### ~~Update details.~~
- added
  - `uint8ArrayToBlob()`
  - `textToBlob()`
- updated
  - `newBlob()`
  - `arrayBufferToBlob()`
  - `dataURLToBlob()`
  - `base64ToBlob()`
- removed (incorrect and unnecessary convert)
  - ~~`base64ToArrayBuffer()`~~
  - ~~`base64ToUint8Array()`~~
  - ~~`arrayBufferToBase64()`~~
  - ~~`uint8ArrayToBase64()`~~
